### PR TITLE
Remove dh_pypy leftover / Compatibility with Bookworm

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,4 +4,4 @@ export DH_VERBOSE=1
 export PYBUILD_NAME=arpreq
 
 %:
-	dh $@ --with python3,pypy --buildsystem pybuild
+	dh $@ --with python3 --buildsystem pybuild


### PR DESCRIPTION
dh_pypy got removed from dh-python in bookworm

This enables packaging for bookworm.